### PR TITLE
Removed unnecessary redirect

### DIFF
--- a/library/Netboximport/Api.php
+++ b/library/Netboximport/Api.php
@@ -26,7 +26,7 @@ class Api {
         $get_params['limit'] = 1000000;
 
         $query = http_build_query($get_params);
-        curl_setopt($ch, CURLOPT_URL, $this->baseurl . ltrim($url, '/') . '?' . $query);
+        curl_setopt($ch, CURLOPT_URL, $this->baseurl . trim($url, '/') . '/?' . $query);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, array(
             'Authorization: Token ' . $this->apitoken,


### PR DESCRIPTION
Every time the Importer makes a request to the API the webserver returns a 301 with a redirect. This is fixed with this patch


Before:
>[10/Aug/2018:20:19:33 +0200] "GET /api/dcim/devices?limit=1000000 HTTP/1.1" 301 0 "-" "-"
>[10/Aug/2018:20:19:33 +0200] "GET /api/dcim/devices/?limit=1000000 HTTP/1.1" 200 41090 "-" "-"

After:
>[10/Aug/2018:20:33:29 +0200] "GET /api/dcim/devices/?limit=1000000 HTTP/1.1" 200 41090 "-" "-"
