### PR TITLE
Updated use of API Calls with full URL

### DIFF
--- a/library/Netboximport/Api.php
+++ b/library/Netboximport/Api.php
@@ -16,6 +16,10 @@ class Api {
     private function apiRequest($method, $url, $get_params) {
         if ($this->startsWith($url, $this->baseurl)) {
             $url = substr($url, strlen($this->baseurl));
+        } else if ($this->startsWith(preg_replace("/^http:/i", "https:", $url), $this->baseurl)) {
+            $url = substr($url, strlen($this->baseurl)-1);
+        } else if ($this->startsWith(preg_replace("/^https:/i", "http:", $url), $this->baseurl)) {
+            $url = substr($url, strlen($this->baseurl)+1);
         }
 
         $ch = curl_init();


### PR DESCRIPTION
This fix cleans up API Requests which contain the $baseurl in a modified form. It now detects the usage of HTTP / HTTPS and also removes this modified $baseurl from the $url

This PR fixes #4.