### PR TITLE
Update for Netbox 2.10.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ In some cases additional fields are provided:
 * `interfaces` is added, so configured IP addresses can be reused in icinga
 * `services` is added, so configured services can be reused in icinga
 
+### Tag split delimiter
+A Tag in netbox is only one value. But if your tags are imported by different hyperscaler, you have often a key value pair. So if you import this key value pair into netbox you have to chose a delimiter. In our case tags a are like:
+````
+thisisatag::true
+````
+To Work with the key and the value in icinga2, you need a json hash. If you have a different delimiter, you can set this herre.
+If you have no delimiter, you can ignore this field.
+
 ## Acknowledgements
 
 The general structure and a few tips were lifted from [icingaweb2-module-fileshipper](https://github.com/Icinga/icingaweb2-module-fileshipper).

--- a/README.md
+++ b/README.md
@@ -78,11 +78,7 @@ A Tag in netbox is only one value. But if your tags are imported by different hy
 ````
 thisisatag::true
 ````
-<<<<<<< HEAD
 To Work with the key and the value in icinga2, you need a json hash. If you have a different delimiter, you can set this here.
-=======
-To Work with the key and the value in icinga2, you need a json hash. If you have a different delimiter, you can set this herre.
->>>>>>> af5452cf085b7b56cda9f87f53156cbbd00a12df
 If you have no delimiter, you can ignore this field.
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ In some cases additional fields are provided:
 * `interfaces` is added, so configured IP addresses can be reused in icinga
 * `services` is added, so configured services can be reused in icinga
 
+### Tag split delimiter
+A Tag in netbox is only one value. But if your tags are imported by different hyperscaler, you have often a key value pair. So if you import this key value pair into netbox you have to chose a delimiter. In our case tags a are like:
+````
+thisisatag::true
+````
+To Work with the key and the value in icinga2, you need a json hash. If you have a different delimiter, you can set this here.
+If you have no delimiter, you can ignore this field.
+
 ## Acknowledgements
 
 The general structure and a few tips were lifted from [icingaweb2-module-fileshipper](https://github.com/Icinga/icingaweb2-module-fileshipper).

--- a/library/Netboximport/Api.php
+++ b/library/Netboximport/Api.php
@@ -3,9 +3,9 @@
 namespace Icinga\Module\Netboximport;
 
 class Api {
-    function __construct($baseurl, $apitoken, $ssl_verify) {
+    function __construct($baseurl, $apitoken, $ignore_ssl_verification) {
         $this->baseurl = rtrim($baseurl, '/') . '/';
-        $this->ssl_verify = $ssl_verify;
+        $this->ignore_ssl_verification = $ignore_ssl_verification;
         $this->apitoken = $apitoken;
         $this->cache = [];
     }
@@ -29,7 +29,7 @@ class Api {
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
 
         // If ssl_verify is set, check ssl certificate from netbox host
-        if ($this->ssl_verify === "0") {
+        if ($this->ignore_ssl_verification === "1") {
             curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
         }
 

--- a/library/Netboximport/Api.php
+++ b/library/Netboximport/Api.php
@@ -3,8 +3,9 @@
 namespace Icinga\Module\Netboximport;
 
 class Api {
-    function __construct($baseurl, $apitoken) {
+    function __construct($baseurl, $apitoken, $ssl_verify) {
         $this->baseurl = rtrim($baseurl, '/') . '/';
+        $this->ssl_verify = $ssl_verify;
         $this->apitoken = $apitoken;
         $this->cache = [];
     }
@@ -26,6 +27,12 @@ class Api {
 
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+
+        // If ssl_verify is set, check ssl certificate from netbox host
+        if ($this->ssl_verify === "0") {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+        }
+
 
         $get_params['limit'] = 1000000;
 

--- a/library/Netboximport/ProvidedHook/Director/ImportSource.php
+++ b/library/Netboximport/ProvidedHook/Director/ImportSource.php
@@ -232,10 +232,10 @@ class ImportSource extends ImportSourceHook {
             'description' => $form->translate('API url for your instance, e.g. https://netbox.example.com/api')
         ));
 
-        $form->addElement('checkbox', 'ssl_verify', array(
-            'label'       => $form->translate('SSL Verify'),
+        $form->addElement('checkbox', 'ignore_ssl_verification', array(
+            'label'       => $form->translate('Ignore SSL Verification'),
             'required'    => false,
-            'description' => $form->translate('Verify SSL Certs')
+            'description' => $form->translate('Ignore SSL Verification')
         ));
 
         $form->addElement('text', 'apitoken', array(
@@ -286,7 +286,7 @@ class ImportSource extends ImportSourceHook {
 
     public function fetchData() {
         $baseurl = $this->getSetting('baseurl');
-        $ssl_verify = $this->getSetting('ssl_verify');
+        $ignore_ssl_verification = $this->getSetting('ignore_ssl_verification');
         $apitoken = $this->getSetting('apitoken');
         $tag_split_delimiter = $this->getSetting('tag_split_delimiter');
 
@@ -300,7 +300,7 @@ class ImportSource extends ImportSourceHook {
         $autoflatten_elements = explode(",",$this->getSetting('autoflattenelements'));
         $this->resolve_properties = explode(",",$this->getSetting('resolveproperties'));
 
-        $this->api = new Api($baseurl, $apitoken, $ssl_verify);
+        $this->api = new Api($baseurl, $apitoken, $ignore_ssl_verification);
         $this->interfaces = $this->fetchInterfaces();
         $this->services = $this->fetchServices($service_elements);
 

--- a/library/Netboximport/ProvidedHook/Director/ImportSource.php
+++ b/library/Netboximport/ProvidedHook/Director/ImportSource.php
@@ -91,7 +91,7 @@ class ImportSource extends ImportSourceHook {
 
            return $children;
         });
-        
+
         return $hosts;
     }
 
@@ -232,6 +232,12 @@ class ImportSource extends ImportSourceHook {
             'description' => $form->translate('API url for your instance, e.g. https://netbox.example.com/api')
         ));
 
+        $form->addElement('checkbox', 'ssl_verify', array(
+            'label'       => $form->translate('SSL Verify'),
+            'required'    => false,
+            'description' => $form->translate('Verify SSL Certs')
+        ));
+
         $form->addElement('text', 'apitoken', array(
             'label'       => $form->translate('API-Token'),
             'required'    => true,
@@ -270,12 +276,20 @@ class ImportSource extends ImportSourceHook {
             'description' => $form->translate('Some nested objects can be resolved instead of just referenced e.g. [ cluster,interfaces ] (comma seperated)'),
             'value'       => 'cluster',
         ));
+
+        $form->addElement('text','tag_split_delimiter', array(
+            'label'       => $form->translate('Tag Split Delimiter'),
+            'description' => $form->translate('Set the delimiter to split your tag in key and value. For more details: README.md'),
+            'value'       => '',
+        ));
     }
 
     public function fetchData() {
         $baseurl = $this->getSetting('baseurl');
+        $ssl_verify = $this->getSetting('ssl_verify');
         $apitoken = $this->getSetting('apitoken');
-        
+        $tag_split_delimiter = $this->getSetting('tag_split_delimiter');
+
         if ($this->getSetting('activeonly') === 'y') {
             $activeonly = 'active';
         } else {
@@ -286,7 +300,7 @@ class ImportSource extends ImportSourceHook {
         $autoflatten_elements = explode(",",$this->getSetting('autoflattenelements'));
         $this->resolve_properties = explode(",",$this->getSetting('resolveproperties'));
 
-        $this->api = new Api($baseurl, $apitoken);
+        $this->api = new Api($baseurl, $apitoken, $ssl_verify);
         $this->interfaces = $this->fetchInterfaces();
         $this->services = $this->fetchServices($service_elements);
 
@@ -300,8 +314,35 @@ class ImportSource extends ImportSourceHook {
             $objects[] = $this->fetchHosts('virtualization/virtual-machines', 'virtual_machine', $activeonly, $autoflatten_elements);
         }
 
-        return array_merge(...$objects);
+        $objects = array_merge(...$objects);
 
+        /*
+        I couldn't find the change in the netbox changelog but they changed that tags now returned as an object and no longer as an array.
+        Furthermore I added the posibillity to split tags to a key value pair.
+        */
+        foreach ($objects as $object) {
+            $host_tags = array();
+            foreach ($object->tags as $tags) {
+                if ($tag_split_delimiter) {
+                    $tag = explode($tag_split_delimiter, $tags->name);
+                    if (count($tag) > 1 ) {
+                        $key = $tag[0];
+                        $value = $tag[1];
+                    } else {
+                        $key = $tag[0];
+                        $value = "true";
+                    }
+
+                    $host_tags[$key] = $value;
+                } else {
+                    array_push($host_tags, $tags->name);
+                }
+
+            $object->tags = $host_tags;
+            }
+        }
+
+        return $objects;
     }
 
     public function listColumns() {


### PR DESCRIPTION
- Added ssl verify option. Now its possible to disable ssl verification.
- Added Tag Split to key value
- Changed Tag handling after netbox update

We updated our netbox instance. After that the following error occurred:
`could not be converted to string`

The problem is, that they changed the api response of a tag:

Before Update (2.8.8):
```
[...]
[dns_name] =>
[description] => azure_reserved
[tags] => Array
	(
		[0] => tag1
		[1] => tag2
	)

[custom_fields] => stdClass Object
	(
	)

```

After Update (Version: 2.10.5):
```
[...]
[dns_name] =>
[description] => azure_reserved
[tags] => Array
	(
		[0] => stdClass Object
			(
				[id] => 67
				[url] => https://10.138.1.131/api/extras/tags/67/
				[name] => azure_reserved
				[slug] => azure_reserved
				[color] => 9e9e9e
			)

	)

[custom_fields] => stdClass Object
	(
	)
```

I'm no php programmer (to be honest, I'm not a programmer at all), so my code is really bad. Maybe one of the maintainer is able to
translate my code (my bad code -> really good code)

Thanks a lot
Cheers Mordecaine